### PR TITLE
Fix line ending issue

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 module.exports = (filename) => {
   let num = null;
+  filename = filename.replace(/[\r\n]$/, ""); // remove extra newlines from end of string
   filename = filename.replace(/((?:\.mp4)+)$/, ""); // remove file extension
   filename = filename.replace(/(v\d)$/i, ""); // remove v2, v3 suffix
   filename = filename.replace(/(\d)v[0-5]/i, "$1"); // remove v2 from 13v2


### PR DESCRIPTION
The tool previously incorrectly extracted episode numbers when the string ended with a carriage return and line feed, which led to the accuracy dropping from 99% to 97%. I believe this is a Windows issue as Windows has different line endings than Linux.