### PR TITLE
Remove resolution string like (BD)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ module.exports = (filename) => {
   filename = filename.replace(/\(\d+(?:x|X|×)\d+\)/, ""); // remove resolutions like (1280x720)
   filename = filename.replace(/(?:1920|1080|1280|720|1024|576)(?:p|P|x|X|×)/, "x"); // remove resolutions like 720 or 1080
   filename = filename.replace(/((19|20)\d\d)/, ""); // remove years like 1999 or 2019
+  filename = filename.replace(/\(BD\)/, ""); // remove resolution like (BD)
 
   num = filename.match(/^(\d{1,4})(?:-|~)(\d{1,4})$/); // 13.mp4
   if (num !== null) {

--- a/test/minimal.txt
+++ b/test/minimal.txt
@@ -5,3 +5,4 @@ null	[Ohys-Raws] Boku no Kanojo ga Majime Sugiru Shobitch na Ken (2018) - OVA (B
 13	[Ohys-Raws] Amanchu! - 13 OVA (AT-X 1280x720 x264 AAC).mp4
 1,2	[Ohys-Raws] Idolish Seven - 01-02 (MX 1280x720 x264 AAC).mp4
 10|11	[Ohys-Raws] High School DxD Hero - 11(10) (AT-X 1280x720 x264 AAC).mp4
+1	Himitsu Sentai Goranger 01(BD).mp4


### PR DESCRIPTION
Before, `npm run quick-test`
>
> aniep@0.4.0 quick-test
> node test/run-quick-test.js
>
>
> aniep@0.4.0 quick-test
>
> aniep@0.4.0 quick-test
> node test/run-quick-test.js
>
>Expect:      1 | Got:   null | Himitsu Sentai Goranger 01(BD).mp4
>
>Minimal test (87.5000%)
>     7/8 testcases passed (87.5000%)
>     1/8 testcases failed (12.5000%)
>
> 

After, `npm run quick-test`

> aniep@0.4.0 quick-test
> node test/run-quick-test.js
>
> aniep@0.4.0 quick-test
> node test/run-quick-test.js
>
>
>Minimal test (100.0000%)
>     8/8 testcases passed (100.0000%)
>     0/8 testcases failed (0.0000%)
>

`npm run coverage` outputs are the same.

> 
>Leopard-Raws + Ohys-Raws dataset (99.9730%)
> 25954/25961 testcases passed (99.9730%)
>     7/25961 testcases failed (0.0270%)
>
>Chinese dataset (99.8699%)
> 52986/53055 testcases passed (99.8699%)
>    69/53055 testcases failed (0.1301%)
>
>All test (99.7474%)
>143738/144102 testcases passed (99.7474%)
>   364/144102 testcases failed (0.2526%)

Since `answer.txt` is generated upon 'find /mnt/data/anime -type f -name "*.mp4"', not add the new test case to `answer.txt` but `minimal.txt`