### PR TITLE
Remove mkv

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 module.exports = (filename) => {
   let num = null;
   filename = filename.replace(/[\r\n]$/, ""); // remove extra newlines from end of string
-  filename = filename.replace(/((?:\.mp4)+)$/, ""); // remove file extension
+  filename = filename.replace(/((?:\.mp4|\.mkv)+)$/, ""); // remove file extension
   filename = filename.replace(/(v\d)$/i, ""); // remove v2, v3 suffix
   filename = filename.replace(/(\d)v[0-5]/i, "$1"); // remove v2 from 13v2
   filename = filename.replace(/x26(4|5)/i, ""); // remove x264 and x265

--- a/test/minimal.txt
+++ b/test/minimal.txt
@@ -6,3 +6,4 @@ null	[Ohys-Raws] Boku no Kanojo ga Majime Sugiru Shobitch na Ken (2018) - OVA (B
 1,2	[Ohys-Raws] Idolish Seven - 01-02 (MX 1280x720 x264 AAC).mp4
 10|11	[Ohys-Raws] High School DxD Hero - 11(10) (AT-X 1280x720 x264 AAC).mp4
 1	Himitsu Sentai Goranger 01(BD).mp4
+153	Dragon Ball - Episódio 153.mkv


### PR DESCRIPTION
I had some problems identifying the episode when the file is in mkv like `Dragon Ball - Episódio 153.mkv`

Before:
```
> aniep@0.4.1 quick-test     
> node test/run-quick-test.js

Expect:    153 | Got:   null | Dragon Ball - Episódio 153.mkv

Minimal test (88.8889%)
     8/9 testcases passed (88.8889%)
     1/9 testcases failed (11.1111%)
```

After:
```
> aniep@0.4.1 quick-test     
> node test/run-quick-test.js


Minimal test (100.0000%)
     9/9 testcases passed (100.0000%)
     0/9 testcases failed (0.0000%)
```

With `npm run coverage` there were no changes
```
Chinese dataset (99.8735%)
 54485/54554 testcases passed (99.8735%)
    69/54554 testcases failed (0.1265%)

All test (99.7583%)
150265/150629 testcases passed (99.7583%)
   364/150629 testcases failed (0.2417%)
```